### PR TITLE
Create allow_styles_and_images_and_fonts_same_site.ruleset

### DIFF
--- a/general/allow_styles_and_images_and_fonts_same_site.ruleset
+++ b/general/allow_styles_and_images_and_fonts_same_site.ruleset
@@ -1,0 +1,13 @@
+magic: policeman_ruleset
+version: 0.1
+id: "allow_styles_and_images_and_fonts_same_site"
+
+l10n:
+  en-US:
+    name: "Allow styles, images, and fonts from same site"
+    description: "Allow styles, images, and fonts from same second-level domain"
+
+rules:
+  [contentType] (STYLESHEET|IMAGE|FONT):
+    [schemeType] web -> web:
+      [baseDomain] * -> $&: ACCEPT


### PR DESCRIPTION
New rule to complement the already existing "Stylesheet and Images from same site" rule.
This rule adds fonts needed for proper rendering of websites. Since they are not XSS'd I'm not seeing a big impact on privacy.
This rule will help reduce a few clicks in the popup GUI.
